### PR TITLE
Label the deliberately insecure templates, and fix the ones that were not meant to be

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# macOS
+.DS_Store
+
+# Logs
+*.log
+
+# Environment files and anything shaped like a credential. This repository is entirely about
+# AWS access control, and several walkthroughs have you create keys, roles and key pairs.
+.env
+.env.*
+*.pem
+*.key
+*.p12
+*.pfx
+credentials*
+secrets/
+
+# Local AWS config, which is where the credentials this repo talks about actually live
+.aws/
+kubeconfig
+kubeconfig.yaml
+
+# Tool output
+node_modules/
+__pycache__/
+*.sqlite
+*.db
+
+# cloudsploit clones its scan definitions here (was security/.gitignore)
+security/cloudsploit/scans

--- a/IAM-role-for-users/README.md
+++ b/IAM-role-for-users/README.md
@@ -14,7 +14,7 @@ Example output:
         "Path": "/", 
         "CreateDate": "2020-06-22T16:42:13Z", 
         "UserId": "***", 
-        "Arn": "arn:aws:iam::your-aws-account-id:user/test-us-1"
+        "Arn": "arn:aws:iam::YOUR-ACCOUNT-ID:user/test-us-1"
     }
 }
 ```
@@ -29,7 +29,7 @@ Example output:
 ```json
 {
     "VirtualMFADevice": {
-        "SerialNumber": "arn:aws:iam::your-aws-account-id:mfa/test-us-1-virtual-mfa"
+        "SerialNumber": "arn:aws:iam::YOUR-ACCOUNT-ID:mfa/test-us-1-virtual-mfa"
     }
 }
 ```
@@ -41,7 +41,7 @@ First, open your `Authenticator`, for example: `Google Authenticator` and scan t
 Then, add 2 codes...
 
 ```shell
-aws iam enable-mfa-device --user-name test-us-1 --serial-number arn:aws:iam::your-aws-account-id:mfa/test-us-1-virtual-mfa --authentication-code-1 360431 --authentication-code-2 874344
+aws iam enable-mfa-device --user-name test-us-1 --serial-number arn:aws:iam::YOUR-ACCOUNT-ID:mfa/test-us-1-virtual-mfa --authentication-code-1 360431 --authentication-code-2 874344
 ```
 
 Then, we are going to list all MFA devices for our user and ensure 
@@ -56,7 +56,7 @@ We should see something like:
     "MFADevices": [
         {
             "UserName": "test-us-1", 
-            "SerialNumber": "arn:aws:iam::your-aws-account-id:mfa/test-us-1-virtual-mfa", 
+            "SerialNumber": "arn:aws:iam::YOUR-ACCOUNT-ID:mfa/test-us-1-virtual-mfa", 
             "EnableDate": "2020-06-22T17:05:12Z"
         }
     ]
@@ -131,8 +131,8 @@ List all object inside a bucket `aws s3api list-objects --bucket your-bucket --q
 
 Now, if we try: `aws iam list-users` we should see...
 
-```shell
-An error occurred (AccessDenied) when calling the ListUsers operation: User: arn:aws:iam::your-aws-account-id:user/test-us-1 is not authorized to perform: iam:ListUsers on resource: arn:aws:iam::your-aws-account-id:user/
+```text
+An error occurred (AccessDenied) when calling the ListUsers operation: User: arn:aws:iam::YOUR-ACCOUNT-ID:user/test-us-1 is not authorized to perform: iam:ListUsers on resource: arn:aws:iam::YOUR-ACCOUNT-ID:user/
 ```
 
 ## Option 2: Create a role the user can utilize
@@ -156,7 +156,7 @@ Result:
         "PolicyId": "***", 
         "DefaultVersionId": "v1", 
         "Path": "/", 
-        "Arn": "arn:aws:iam::your-aws-account-id:policy/test-user-policy", 
+        "Arn": "arn:aws:iam::YOUR-ACCOUNT-ID:policy/test-user-policy", 
         "UpdateDate": "2020-06-22T18:09:45Z"
     }
 }
@@ -180,7 +180,7 @@ In our case, we expect the following response
 Let's assign the policy `test-user-policy` that we created in the previous step.
 
 ```shell
-aws iam attach-user-policy --policy-arn arn:aws:iam::your-aws-account-id:policy/test-user-policy --user-name test-us-1
+aws iam attach-user-policy --policy-arn arn:aws:iam::YOUR-ACCOUNT-ID:policy/test-user-policy --user-name test-us-1
 ```
 
 And... Ensure the user now has the proper policy
@@ -196,7 +196,7 @@ Result:
     "AttachedPolicies": [
         {
             "PolicyName": "test-user-policy", 
-            "PolicyArn": "arn:aws:iam::your-aws-account-id:policy/test-user-policy"
+            "PolicyArn": "arn:aws:iam::YOUR-ACCOUNT-ID:policy/test-user-policy"
         }
     ]
 }
@@ -221,7 +221,7 @@ Result:
                 "Action": "sts:AssumeRole", 
                 "Effect": "Allow", 
                 "Principal": {
-                    "AWS": "arn:aws:iam::your-aws-account-id:user/test-us-1"
+                    "AWS": "arn:aws:iam::YOUR-ACCOUNT-ID:user/test-us-1"
                 }
             }
         }, 
@@ -229,12 +229,12 @@ Result:
         "CreateDate": "2020-06-22T20:48:08Z", 
         "RoleName": "test-user-role", 
         "Path": "/", 
-        "Arn": "arn:aws:iam::your-aws-account-id:role/test-user-role"
+        "Arn": "arn:aws:iam::YOUR-ACCOUNT-ID:role/test-user-role"
     }
 }
 ```
 
-Until now, the user has only permissions to assume the role `test-user-role` in a particular account `your-aws-account-id`
+Until now, the user has only permissions to assume the role `test-user-role` in a particular account `YOUR-ACCOUNT-ID`
 
 4. Attach policy to role
 
@@ -249,7 +249,7 @@ You should see...
 **Trusted entities**
 The following trusted entities can assume this role.
 Trusted entities
-The account `your-aws-account-id`
+The account `YOUR-ACCOUNT-ID`
 
 **Conditions**
 The following conditions define how and when trusted entities can assume the role.
@@ -300,13 +300,13 @@ aws iam delete-role --role-name test-user-role
 
 First we need to detach the policy from the user entity.
 ```shell
-aws iam detach-user-policy --user-name test-us-1 --policy-arn arn:aws:iam::your-aws-account-id:policy/test-user-policy
+aws iam detach-user-policy --user-name test-us-1 --policy-arn arn:aws:iam::YOUR-ACCOUNT-ID:policy/test-user-policy
 ```
 
 Then,
 
 ```shell
-aws iam delete-policy --policy-arn arn:aws:iam::your-aws-account-id:policy/test-user-policy  
+aws iam delete-policy --policy-arn arn:aws:iam::YOUR-ACCOUNT-ID:policy/test-user-policy  
 ```
 
 ## For both (Option 1 and Option 2)
@@ -317,9 +317,9 @@ aws iam delete-policy --policy-arn arn:aws:iam::your-aws-account-id:policy/test-
 First we need to deactivate, then delete.
 
 ```shell
-aws iam deactivate-mfa-device --user-name test-us-1 --serial-number arn:aws:iam::your-aws-account-id:mfa/test-us-1-virtual-mfa
+aws iam deactivate-mfa-device --user-name test-us-1 --serial-number arn:aws:iam::YOUR-ACCOUNT-ID:mfa/test-us-1-virtual-mfa
 
-aws iam delete-virtual-mfa-device --serial-number arn:aws:iam::your-aws-account-id:mfa/test-us-1-virtual-mfa
+aws iam delete-virtual-mfa-device --serial-number arn:aws:iam::YOUR-ACCOUNT-ID:mfa/test-us-1-virtual-mfa
 ```
 
 2. Delete user access keys

--- a/IAM-role-for-users/policy.json
+++ b/IAM-role-for-users/policy.json
@@ -1,8 +1,10 @@
 {
   "Version": "2012-10-17",
-  "Statement": {
-    "Effect": "Allow",
-    "Action": "sts:AssumeRole",
-    "Resource": "arn:aws:iam::your-account-id:role/test-user-role"
-  }
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "sts:AssumeRole",
+      "Resource": "arn:aws:iam::YOUR-ACCOUNT-ID:role/test-user-role"
+    }
+  ]
 }

--- a/IAM-role-for-users/test-trust-policy.json
+++ b/IAM-role-for-users/test-trust-policy.json
@@ -1,9 +1,17 @@
 {
   "Version": "2012-10-17",
-  "Statement": {
-    "Effect": "Allow",
-    "Principal": { "AWS": "arn:aws:iam::your-aws-account-id:root" },
-    "Action": "sts:AssumeRole",
-    "Condition": { "Bool": { "aws:MultiFactorAuthPresent": "true" } }
-  }
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::YOUR-ACCOUNT-ID:root"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "Bool": {
+          "aws:MultiFactorAuthPresent": "true"
+        }
+      }
+    }
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -1,1 +1,130 @@
-# AWS various
+# AWS
+
+Working notes from mid-2020, six topics, each a directory or a markdown file with the commands
+and their recorded output. Not an application: the point is the walkthroughs and the policy
+documents beside them.
+
+| | |
+| --- | --- |
+| [`security/`](security/) | A security training project: deploy a deliberately vulnerable stack, attack it, then harden it. **The infrastructure there is intentionally insecure. See the caution below.** |
+| [`encryption/`](encryption/) | Server-side encryption with a KMS customer managed key, by CLI |
+| [`encryption/application/`](encryption/application/) | The same thing as two Lambdas, one writing and one reading |
+| [`SSM/`](SSM/) | An EC2 instance reachable only through Session Manager: no port 22, no key pair |
+| [`IAM-role-for-users/`](IAM-role-for-users/) | Role switching for IAM users, with MFA required |
+| [`cloudtrail.md`](cloudtrail.md) | CloudTrail to an S3 bucket, with the bucket policy CloudTrail needs |
+| [`cloudwatch-alarms-billing.md`](cloudwatch-alarms-billing.md) | A billing alarm and the SNS topic it notifies |
+
+## ⚠️ `security/` is deliberately insecure
+
+That directory is training material. `security/infrastructure/app.yml` opens `IpProtocol: -1`
+from `0.0.0.0/0` twice, plus SSH on 22, and ports 5000 and 80, all to the internet.
+`security/infrastructure/s3.yml` creates three buckets, one named `secret-recipes`, with no
+encryption at rest, no public-access block and no versioning.
+
+**None of that has been fixed, on purpose.** The vulnerabilities are what the exercises attack,
+and the hardening exercise deliberately fixes SSH inside `sshd_config` on the running instance
+rather than in the template. Every file in there now carries a header saying so, because the
+templates are otherwise indistinguishable from a reference someone might copy.
+
+Everything outside `security/` is meant to be sound, and is where the corrections below apply.
+
+## What changed, and why
+
+**A demo about encryption was printing the plaintext to the logs.**
+`encryption/application/encryption-lambda-read.js` ended with
+
+```js
+console.log(data.Body.toString('utf-8'))
+```
+
+so the last act of a function whose entire purpose is to show that an object is encrypted at
+rest with KMS was to write the decrypted content into CloudWatch Logs. Logs are a different
+boundary from the bucket: not encrypted with that key, readable by anyone holding
+`logs:FilterLogEvents`, and persisting independently of the object. It now logs the byte count
+and the SSE algorithm S3 reports, and returns the body to the caller instead, where the demo
+still demonstrates what it meant to.
+
+**Both Lambdas reported success when they had failed.** Each caught its own errors with
+`console.log(err)` and returned `undefined`, so a denied `kms:Decrypt`, a missing object or a
+wrong bucket produced a *successful* invocation with nothing to show. They rethrow now, which is
+what makes the invocation fail, retry per its configuration and appear in metrics. Only the
+error's `name` and `code` are logged, because an AWS SDK error message can carry the bucket, the
+key and the whole request.
+
+The bucket, object key and KMS key also came from the source rather than the environment, one of
+them a specific key ARN that no one else can use. They come from `process.env` now.
+
+**Two IAM policies could disable the account's own monitoring.**
+`cloudwatch-alarms-billing-CloudWatchMetricsPolicyForBilling.json` granted
+`cloudwatch:SetAlarmState` and `cloudwatch:DeleteAlarms` on `Resource: "*"`, which is permission
+to silence or delete *every* alarm in the account. Verified against the CloudWatch
+service-authorization reference: those two, plus `PutMetricAlarm` and `DescribeAlarms`, accept an
+alarm ARN, while `PutMetricData`, `GetMetricStatistics` and `ListMetrics` are defined without a
+resource type and can only be `*`. So the policy is split along that line and the alarm half is
+scoped to `alarm:billing-*`. Same treatment for `sns:DeleteTopic`, which was on `*` and could
+have deleted any topic in the account.
+
+**`SSM/SSM.yml` could not be deployed as written.** Four separate reasons:
+
+- `ImageId: ami-0323c3dd2da7fb37d` was hardcoded. An AMI id is valid only in the region that
+  published it and Amazon deregisters old ones, so the template failed outside `us-east-1` and
+  eventually failed there too. It now takes the public SSM parameter
+  `/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2`. Amazon Linux 2 is an inference
+  rather than a certainty: the original id cannot be resolved any more, but the template installs
+  no SSM agent, so the image it used must have shipped one.
+- `RoleName` was hardcoded twice, which makes the stack undeployable a second time and collides
+  with anything else using those names. Both are omitted so CloudFormation generates them.
+- The security group had no `VpcId`, so it landed in the default VPC and the stack failed
+  outright in any account whose default VPC has been removed.
+- The login role trusted `Principal: root`, meaning every identity in the account. It now
+  requires MFA, which is the same condition the sibling `IAM-role-for-users/test-trust-policy.json`
+  already applied, so the repository had been inconsistent with itself.
+
+`AmazonEC2ReadOnlyAccess` is also dropped from that role: it grants read access to every EC2
+resource in the account, and the role only needs to find the one instance it connects to.
+
+One thing in that file is **deliberately** not a `!Sub`:
+
+```yaml
+Resource: arn:aws:ssm:*:*:session/${aws:username}-*
+```
+
+`${aws:username}` is an IAM policy variable that IAM expands at evaluation time, so it has to
+reach IAM as a literal. Wrapping it in `!Sub` makes CloudFormation try to resolve it: verified
+with `cfn-lint`, which reports `E1019 'aws:username' is not one of [...]`.
+
+**Placeholders were spelled four different ways** — `your-aws-account-id`, `your-account-id`,
+`your-admin-account-id` — alongside a concrete bucket name and a real KMS key id that read as
+placeholders but were not. All now `YOUR-ACCOUNT-ID`, `YOUR-BUCKET-NAME` and `YOUR-KMS-KEY-ID`.
+The exercise answers under `security/txt/` are left exactly as written.
+
+**`validate-policies.py`** checks every `*.json` policy in the repository against the IAM
+grammar, which is a *closed* set of keys: a stray element is rejected with
+`MalformedPolicyDocument`, so it makes the file unusable rather than untidy.
+
+```shell
+python3 validate-policies.py
+```
+
+That check exists because writing this README broke two policies. Explanatory `"Comment"` keys
+were added to five statements, which IAM does not permit, and JSON has no comment syntax to use
+instead — which is why every explanation lives here rather than in the policy files.
+
+The first version of the checker was also over-strict, and that is worth recording: it applied
+the alphanumeric-only `Sid` rule to the KMS key policies and reported six valid statements as
+broken. That rule is for IAM *identity* policies; resource policies permit more, and the AWS
+console itself generates `Sid: "Allow access for Key Administrators"`. The rule is now applied
+only to statements without a `Principal`. A linter that reports valid input is worse than none,
+because the next person changes the input to satisfy it.
+
+## Not covered
+
+- **Nothing here has been run against AWS.** There are no credentials in this environment. The
+  policies are validated against the IAM grammar, the templates with `cfn-lint`, and the Lambda
+  sources with `node --check`; the recorded command output is from 2020.
+- **`security/` is unchanged apart from the warnings.** Hardening it would destroy the exercises.
+- **The two key policies under `encryption/` differ on purpose.** The one in `application/` is the
+  same as the top-level one plus permission for the two Lambda roles to use the key, because the
+  serverless walkthrough is the later stage. Neither is stale.
+- **`cloudtrail.md` and `cloudwatch-alarms-billing.md` keep their recorded output**, including
+  timestamps and resource ids from the original run.

--- a/README.md
+++ b/README.md
@@ -113,12 +113,14 @@ correct and the variable was wrong.
 One thing in that file is **deliberately** not a `!Sub`:
 
 ```yaml
-Resource: arn:aws:ssm:*:*:session/${aws:username}-*
+Resource: arn:aws:ssm:*:*:session/${aws:userid}-*
 ```
 
-`${aws:username}` is an IAM policy variable that IAM expands at evaluation time, so it has to
+`${aws:userid}` is an IAM policy variable that IAM expands at evaluation time, so it has to
 reach IAM as a literal. Wrapping it in `!Sub` makes CloudFormation try to resolve it: verified
-with `cfn-lint`, which reports `E1019 'aws:username' is not one of [...]`.
+with `cfn-lint`, which reports `E1019 'aws:userid' is not one of [...]`. The same is true of
+`aws:username`, which is what this example used to show — and leaving it there meant a reader
+could copy the variable this branch had just replaced.
 
 **Placeholders were spelled three different ways** — `your-aws-account-id` (54 occurrences),
 `your-admin-account-id` (11) and `your-account-id` (1) — alongside a concrete bucket name and two

--- a/README.md
+++ b/README.md
@@ -16,10 +16,13 @@ documents beside them.
 
 ## ⚠️ `security/` is deliberately insecure
 
-That directory is training material. `security/infrastructure/app.yml` opens `IpProtocol: -1`
-from `0.0.0.0/0` twice, plus SSH on 22, and ports 5000 and 80, all to the internet.
-`security/infrastructure/s3.yml` creates three buckets, one named `secret-recipes`, with no
-encryption at rest, no public-access block and no versioning.
+That directory is training material. `security/infrastructure/app.yml` opens **all protocols
+inbound from `0.0.0.0/0`** on the application instance, plus SSH on 22 and ports 5000 and 80, all
+to the internet. `security/infrastructure/s3.yml` creates three buckets, one named
+`secret-recipes`, with no encryption at rest, no public-access block and no versioning.
+
+Four rules in that file match `IpProtocol: -1` with `0.0.0.0/0`, but only one is ingress. The
+other three are egress, which is the default for every security group and is not an exposure.
 
 **None of that has been fixed, on purpose.** The vulnerabilities are what the exercises attack,
 and the hardening exercise deliberately fixes SSH inside `sshd_config` on the running instance
@@ -93,10 +96,14 @@ Resource: arn:aws:ssm:*:*:session/${aws:username}-*
 reach IAM as a literal. Wrapping it in `!Sub` makes CloudFormation try to resolve it: verified
 with `cfn-lint`, which reports `E1019 'aws:username' is not one of [...]`.
 
-**Placeholders were spelled four different ways** — `your-aws-account-id`, `your-account-id`,
-`your-admin-account-id` — alongside a concrete bucket name and a real KMS key id that read as
-placeholders but were not. All now `YOUR-ACCOUNT-ID`, `YOUR-BUCKET-NAME` and `YOUR-KMS-KEY-ID`.
-The exercise answers under `security/txt/` are left exactly as written.
+**Placeholders were spelled three different ways** — `your-aws-account-id` (54 occurrences),
+`your-admin-account-id` (11) and `your-account-id` (1) — alongside a concrete bucket name and two
+real KMS key ids that read as placeholders but were not. All now `YOUR-ACCOUNT-ID`,
+`YOUR-BUCKET-NAME` and `YOUR-KMS-KEY-ID`. The exercise answers under `security/txt/` are left
+exactly as written, being the author's own work.
+
+Recorded command output keeps its original identifiers on purpose, such as the load-balancer
+hostname in `security/README.md`, so those are a stated exception rather than a miss.
 
 **`validate-policies.py`** checks every `*.json` policy in the repository against the IAM
 grammar, which is a *closed* set of keys: a stray element is rejected with

--- a/README.md
+++ b/README.md
@@ -72,9 +72,11 @@ have deleted any topic in the account.
 - `ImageId: ami-0323c3dd2da7fb37d` was hardcoded. An AMI id is valid only in the region that
   published it and Amazon deregisters old ones, so the template failed outside `us-east-1` and
   eventually failed there too. It now takes the public SSM parameter
-  `/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2`. Amazon Linux 2 is an inference
-  rather than a certainty: the original id cannot be resolved any more, but the template installs
-  no SSM agent, so the image it used must have shipped one.
+  `/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64`. **Amazon Linux 2023,
+  not 2** — AL2 reached end of support on 2026-06-30, so defaulting to it would ship an OS that
+  no longer receives security updates. Which family the original used is an inference rather than
+  a fact: the id cannot be resolved any more, but the template installs no SSM agent, so its image
+  must have shipped one, as both AL2 and AL2023 do.
 - `RoleName` was hardcoded twice, which makes the stack undeployable a second time and collides
   with anything else using those names. Both are omitted so CloudFormation generates them.
 - The security group had no `VpcId`, so it landed in the default VPC and the stack failed
@@ -83,8 +85,30 @@ have deleted any topic in the account.
   requires MFA, which is the same condition the sibling `IAM-role-for-users/test-trust-policy.json`
   already applied, so the repository had been inconsistent with itself.
 
-`AmazonEC2ReadOnlyAccess` is also dropped from that role: it grants read access to every EC2
-resource in the account, and the role only needs to find the one instance it connects to.
+**Both managed policies are dropped from that role**, and the second one mattered as much as the
+first. `AmazonEC2ReadOnlyAccess` grants read on every EC2 resource in the account.
+`AmazonSSMReadOnlyAccess` grants `ssm:Describe*`, `ssm:Get*` and `ssm:List*` on every Systems
+Manager resource, which includes reading unrelated Parameter Store values. Everything the workflow
+needs is enumerated in one inline policy instead, and `SSM/README.md` tabulates it.
+
+**The session policy was also incomplete, so the documented command would have failed.** Checked
+against AWS's own sample end-user policy for Session Manager:
+
+- `ssm:StartSession` needs the **document** `SSM-SessionManagerRunShell` as well as the instance.
+  With only the instance ARN, `aws ssm start-session` fails, because Session Manager reads its
+  configuration from that document.
+- `ssmmessages:OpenDataChannel` is a **user** permission, not only an instance one. The instance
+  side comes from `AmazonSSMManagedInstanceCore`; the caller needs this for the data channel.
+- The session ARN used `${aws:username}`, which **can never match here**. Per the IAM
+  condition-key reference, `aws:username` is "always included in the request context for IAM
+  users" while "requests that are made using ... IAM roles do not include this key". This role
+  exists to be assumed, so terminate and resume would always have been denied. It is
+  `${aws:userid}` now, which is what AWS's current samples use.
+
+That last one is worth being blunt about: the previous revision of this README defended the
+`${aws:username}` line at length, verified carefully that it must not be wrapped in `!Sub`, and
+never asked whether the variable was the right one for an assumed role. The `!Sub` reasoning was
+correct and the variable was wrong.
 
 One thing in that file is **deliberately** not a `!Sub`:
 
@@ -107,7 +131,14 @@ hostname in `security/README.md`, so those are a stated exception rather than a 
 
 **`validate-policies.py`** checks every `*.json` policy in the repository against the IAM
 grammar, which is a *closed* set of keys: a stray element is rejected with
-`MalformedPolicyDocument`, so it makes the file unusable rather than untidy.
+`MalformedPolicyDocument`, so it makes the file unusable rather than untidy. It also requires a
+valid `Version`, a non-empty `Statement`, each statement to be an object, `Effect` to be exactly
+`Allow` or `Deny`, exactly one of `Action`/`NotAction`, and a `Resource` on identity policies.
+
+The first version checked only the key names, so it passed `"Effect": "allow"`, an empty
+`Statement: []`, a statement with both `Action` and `NotAction`, and one with neither — and a
+non-object statement crashed it with `AttributeError`, which meant one malformed file hid every
+other file in the run. All seven rules are poison-tested individually.
 
 ```shell
 python3 validate-policies.py

--- a/SSM/README.md
+++ b/SSM/README.md
@@ -13,14 +13,34 @@ The `security group` of the EC2 instance should not allow inbound connections.
 
 We also need the `IAM role` that we will use to login into the instance.
 
-This `role` will have the following managed policies...
+This `role` carries **no managed policies**, and that is a change from how it was first
+written. It used to attach two:
 
-```
-AmazonEC2ReadOnlyAccess
-AmazonSSMReadOnlyAccess
+```text
+AmazonEC2ReadOnlyAccess   read on EVERY EC2 resource in the account
+AmazonSSMReadOnlyAccess   ssm:Describe*, ssm:Get*, ssm:List* on EVERY SSM resource,
+                          which includes reading unrelated Parameter Store values
 ```
 
-... plus, a custom policy to start an terminate sessions (SSM)
+Both are far wider than starting a session on one instance needs, so everything is enumerated
+in a single inline policy instead:
+
+| action | scoped to |
+| --- | --- |
+| `ssm:StartSession` | this instance **and** `document/SSM-SessionManagerRunShell` |
+| `ssmmessages:OpenDataChannel` | `session/${aws:userid}-*` |
+| `ssm:TerminateSession`, `ssm:ResumeSession` | `session/${aws:userid}-*` |
+| `ec2:DescribeInstances`, `ssm:DescribeInstanceInformation`, `ssm:DescribeInstanceProperties`, `ssm:DescribeSessions`, `ssm:GetConnectionStatus` | `*`, because AWS defines these without a resource type |
+
+`StartSession` needs the session **document** as well as the instance: with only the instance
+ARN the command fails, because Session Manager reads its configuration from
+`SSM-SessionManagerRunShell`.
+
+`${aws:userid}` rather than `${aws:username}`, which the first version used. Per the IAM
+condition-key reference, `aws:username` is "always included in the request context for IAM
+users" while "requests that are made using ... IAM roles do not include this key". This role
+exists to be assumed, so `aws:username` is never present and terminate/resume could never
+match their own session.
 
 ```
 Effect: Allow
@@ -51,10 +71,19 @@ aws cloudformation delete-stack --stack-name SSM
 
 ### AWS console
 
-1. Go to IAM > Roles > Search for IAMroleToLoginIntoInstance and select it
+**The role name is generated, not fixed.** `SSM.yml` deliberately omits `RoleName` so the
+stack can be deployed more than once, so take the name from the stack's `LoginRoleArn` output
+rather than searching for a literal:
+
+```shell
+aws cloudformation describe-stacks --stack-name ssm \
+  --query "Stacks[0].Outputs[?OutputKey=='LoginRoleArn'].OutputValue" --output text
+```
+
+1. Go to IAM > Roles and search for the role name from that ARN (the part after `role/`)
 
 2. Click on the link of the key `Give this link to users who can switch roles in the console`
-Example: https://signin.aws.amazon.com/switchrole?roleName=IAMroleToLoginIntoInstance&account=myOrganization
+Example: `https://signin.aws.amazon.com/switchrole?roleName=<the-generated-name>&account=myOrganization`
 
 3. On the new window, click on `Switch Role`
 
@@ -82,16 +111,16 @@ Example: https://signin.aws.amazon.com/switchrole?roleName=IAMroleToLoginIntoIns
 [default]
 region = us-east-1
 
-[profile IAMroleToLoginIntoInstance]
+[profile ssm-login]
 region = us-east-1
-role_arn = arn:aws:iam::YOUR-ACCOUNT-ID:role/IAMroleToLoginIntoInstance
+role_arn = <the LoginRoleArn output from the stack>
 source_profile = default
 ```
 
 2. List EC2 instances
 
 ```shell
-aws ec2 describe-instances --profile IAMroleToLoginIntoInstance
+aws ec2 describe-instances --profile ssm-login
 ```
 
 3. Try something outside the scope of the role
@@ -101,12 +130,12 @@ Anything outside what we are allowing should be denied.
 Let's try to list users.
 
 ```shell
-aws iam list-users --profile IAMroleToLoginIntoInstance
+aws iam list-users --profile ssm-login
 ```
 
 Result:
 ```
-An error occurred (AccessDenied) when calling the ListUsers operation: User: arn:aws:sts::YOUR-ACCOUNT-ID:assumed-role/IAMroleToLoginIntoInstance/botocore-session-********** is not authorized to perform: iam:ListUsers on resource: arn:aws:iam::YOUR-ACCOUNT-ID:user/
+An error occurred (AccessDenied) when calling the ListUsers operation: User: arn:aws:sts::YOUR-ACCOUNT-ID:assumed-role/<the-generated-name>/botocore-session-********** is not authorized to perform: iam:ListUsers on resource: arn:aws:iam::YOUR-ACCOUNT-ID:user/
 ```
 
 Great! Everything works as expected!

--- a/SSM/README.md
+++ b/SSM/README.md
@@ -42,15 +42,11 @@ users" while "requests that are made using ... IAM roles do not include this key
 exists to be assumed, so `aws:username` is never present and terminate/resume could never
 match their own session.
 
-```
-Effect: Allow
-Action ssm:StartSession
-Resource: EC2-arn
-
-Effect: Allow
-Action: ssm:TerminateSession
-Resource: arn:aws:ssm:*:*:session/${aws:username}-*
-```
+The authoritative version is the `SessionManagerAccess` policy in
+[`SSM.yml`](SSM.yml), and it is deliberately not repeated here. A fragment used to sit at this
+spot showing `Resource: EC2-arn` with no document ARN and `${aws:username}` — i.e. the two
+things the paragraphs above explain are wrong — because the prose was corrected and the
+example beside it was not. One copy, in the template, is the fix for that.
 
 ## Creating SSM stack
 ```terminal
@@ -76,7 +72,7 @@ stack can be deployed more than once, so take the name from the stack's `LoginRo
 rather than searching for a literal:
 
 ```shell
-aws cloudformation describe-stacks --stack-name ssm \
+aws cloudformation describe-stacks --stack-name SSM \
   --query "Stacks[0].Outputs[?OutputKey=='LoginRoleArn'].OutputValue" --output text
 ```
 

--- a/SSM/README.md
+++ b/SSM/README.md
@@ -84,7 +84,7 @@ region = us-east-1
 
 [profile IAMroleToLoginIntoInstance]
 region = us-east-1
-role_arn = arn:aws:iam::your-aws-account-id:role/IAMroleToLoginIntoInstance
+role_arn = arn:aws:iam::YOUR-ACCOUNT-ID:role/IAMroleToLoginIntoInstance
 source_profile = default
 ```
 
@@ -106,7 +106,7 @@ aws iam list-users --profile IAMroleToLoginIntoInstance
 
 Result:
 ```
-An error occurred (AccessDenied) when calling the ListUsers operation: User: arn:aws:sts::your-aws-account-id:assumed-role/IAMroleToLoginIntoInstance/botocore-session-********** is not authorized to perform: iam:ListUsers on resource: arn:aws:iam::your-aws-account-id:user/
+An error occurred (AccessDenied) when calling the ListUsers operation: User: arn:aws:sts::YOUR-ACCOUNT-ID:assumed-role/IAMroleToLoginIntoInstance/botocore-session-********** is not authorized to perform: iam:ListUsers on resource: arn:aws:iam::YOUR-ACCOUNT-ID:user/
 ```
 
 Great! Everything works as expected!

--- a/SSM/SSM.yml
+++ b/SSM/SSM.yml
@@ -9,13 +9,16 @@ Parameters:
     # only valid in the region it was published in, and Amazon deregisters old ones, so the
     # template failed outside us-east-1 and eventually failed there too.
     #
-    # Amazon Linux 2 specifically, inferred rather than known: the original AMI id cannot be
-    # resolved any more, but this template has no UserData installing the SSM agent, so the
-    # image it used must have shipped the agent preinstalled. Amazon Linux 2 does. If the
-    # original was Ubuntu, change the parameter path and nothing else.
+    # Amazon Linux 2023, NOT Amazon Linux 2. AL2 reached end of support on 2026-06-30, so it
+    # no longer receives security updates and defaulting to it would ship an unsupported OS.
+    # AL2023 also has the SSM agent preinstalled, which is what this template relies on.
+    #
+    # The original AMI id cannot be resolved any more, so which distribution it was is an
+    # inference rather than a fact: this template installs no SSM agent via UserData, so the
+    # image must have shipped one. Override the parameter if you need a different family.
     Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
-    Default: /aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2
-    Description: SSM public parameter resolving to the latest Amazon Linux 2 AMI.
+    Default: /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64
+    Description: SSM public parameter resolving to the latest Amazon Linux 2023 AMI.
 
   VpcId:
     # Required, rather than relying on the default VPC. The security group below had no VpcId,
@@ -112,37 +115,58 @@ Resources:
               # already applies, so this repository was inconsistent with itself.
               Bool:
                 aws:MultiFactorAuthPresent: 'true'
-      ManagedPolicyArns:
-        # AmazonEC2ReadOnlyAccess was attached and is broader than this role needs: it grants
-        # read access to every EC2 resource in the account. The role only has to find the one
-        # instance it will connect to, which the inline policy below covers, so it is dropped.
-        - arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess
+      # No ManagedPolicyArns at all. Two were attached and both were wider than this role
+      # needs. AmazonEC2ReadOnlyAccess grants read on every EC2 resource in the account.
+      # AmazonSSMReadOnlyAccess grants ssm:Describe*, ssm:Get* and ssm:List* on every Systems
+      # Manager resource, so it could enumerate and read unrelated account-wide SSM data
+      # including parameters. Everything this workflow needs is enumerated inline below.
       Path: /
       Policies:
         - PolicyName: SessionManagerAccess
           PolicyDocument:
             Version: 2012-10-17
             Statement:
+              # StartSession needs BOTH the instance and the session document. Granting only
+              # the instance makes `aws ssm start-session` fail, because Session Manager reads
+              # its configuration from SSM-SessionManagerRunShell. Per AWS's own sample end-user
+              # policy, both ARNs belong in the same statement.
               - Effect: Allow
                 Action: ssm:StartSession
-                Resource: !Sub arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/${EC2Instance}
+                Resource:
+                  - !Sub arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/${EC2Instance}
+                  - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:document/SSM-SessionManagerRunShell
+              # ssmmessages:OpenDataChannel is a USER permission, not only an instance one. The
+              # instance side comes from AmazonSSMManagedInstanceCore on EC2InstanceRole; the
+              # caller needs this to carry the session's data channel.
+              - Effect: Allow
+                Action: ssmmessages:OpenDataChannel
+                Resource: arn:aws:ssm:*:*:session/${aws:userid}-*
               - Effect: Allow
                 Action:
                   - ssm:TerminateSession
                   - ssm:ResumeSession
-                # NOT wrapped in !Sub, deliberately. `${aws:username}` is an IAM policy
-                # variable that IAM expands at evaluation time, so it has to reach IAM as a
-                # literal. Adding !Sub here makes CloudFormation try to resolve it and fail the
-                # stack with "variable aws:username not found".
-                Resource: arn:aws:ssm:*:*:session/${aws:username}-*
+                # ${aws:userid}, NOT ${aws:username}. Per the IAM condition-key reference,
+                # aws:username is "always included in the request context for IAM users" while
+                # "requests that are made using ... IAM roles do not include this key". This
+                # role exists to be ASSUMED, so aws:username is never present and the ARN could
+                # never match: terminate and resume would always be denied. aws:userid is
+                # present for role sessions, and it is what AWS's current samples use.
+                #
+                # Still NOT wrapped in !Sub, for the original reason: this is an IAM policy
+                # variable that IAM expands at evaluation time, so it must reach IAM as a
+                # literal. cfn-lint rejects the !Sub form with
+                # E1019 'aws:userid' is not one of [...].
+                Resource: arn:aws:ssm:*:*:session/${aws:userid}-*
               - Effect: Allow
                 Action:
                   - ec2:DescribeInstances
                   - ssm:DescribeInstanceInformation
+                  - ssm:DescribeInstanceProperties
                   - ssm:DescribeSessions
                   - ssm:GetConnectionStatus
-                # These four are not resource-scopable: AWS defines them without a resource
-                # type, so a narrower ARN would deny rather than restrict. They are read-only.
+                # Not resource-scopable: AWS defines these without a resource type, so a
+                # narrower ARN would deny rather than restrict. All read-only, and they replace
+                # the two managed policies that were attached instead.
                 Resource: '*'
 
 Outputs:
@@ -151,7 +175,9 @@ Outputs:
     Description: Instance to connect to with `aws ssm start-session --target <id>`.
   LoginRoleArn:
     Value: !GetAtt IAMroleToLoginIntoInstance.Arn
-    Description: Role to assume in order to start a session. Requires MFA.
+    Description: >
+      Role to assume in order to start a session. Requires MFA. Use THIS arn in the console
+      role-switch link and in your AWS profile: the role name is generated, not fixed.
   ResolvedAmiId:
     Value: !Ref LatestAmiId
     Description: The AMI the SSM parameter resolved to at deploy time.

--- a/SSM/SSM.yml
+++ b/SSM/SSM.yml
@@ -1,21 +1,60 @@
-Description: SSM
+Description: >
+  An EC2 instance reachable only through SSM Session Manager, with no inbound rules and no key
+  pair, plus a role that a user can assume in order to start a session on it.
+
+Parameters:
+  LatestAmiId:
+    # A public SSM parameter, not a hardcoded AMI id. The original pinned
+    # ami-0323c3dd2da7fb37d, which is region-specific and was current in June 2020: an AMI id is
+    # only valid in the region it was published in, and Amazon deregisters old ones, so the
+    # template failed outside us-east-1 and eventually failed there too.
+    #
+    # Amazon Linux 2 specifically, inferred rather than known: the original AMI id cannot be
+    # resolved any more, but this template has no UserData installing the SSM agent, so the
+    # image it used must have shipped the agent preinstalled. Amazon Linux 2 does. If the
+    # original was Ubuntu, change the parameter path and nothing else.
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: /aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2
+    Description: SSM public parameter resolving to the latest Amazon Linux 2 AMI.
+
+  VpcId:
+    # Required, rather than relying on the default VPC. The security group below had no VpcId,
+    # so CloudFormation placed it in the default VPC; in an account whose default VPC has been
+    # deleted, which is common in anything hardened, stack creation failed with a message about
+    # the group rather than about the VPC.
+    Type: AWS::EC2::VPC::Id
+    Description: VPC to place the instance and its security group in.
+
+  SubnetId:
+    Type: AWS::EC2::Subnet::Id
+    Description: >
+      Subnet for the instance. It needs a route to the SSM endpoints, so either a public subnet
+      or a private one with a NAT gateway or SSM VPC endpoints.
+
+  InstanceType:
+    Type: String
+    Default: t3.micro
+    Description: >
+      t3.micro rather than t2.micro. Same 1 GiB, current generation, and t2 is the previous one.
 
 Resources:
   EC2InstanceRole:
     Type: AWS::IAM::Role
     Properties:
+      # No RoleName. The original hardcoded `ec2-instance-role`, and an explicit name makes the
+      # stack undeployable twice and collides with anything else in the account using it.
+      # CloudFormation generates a unique name when it is omitted.
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
           - Effect: Allow
             Principal:
               Service:
-              - ec2.amazonaws.com
+                - ec2.amazonaws.com
             Action:
               - sts:AssumeRole
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
-      RoleName: ec2-instance-role
 
   EC2InstanceProfile:
     Type: AWS::IAM::InstanceProfile
@@ -26,18 +65,30 @@ Resources:
 
   EC2SecurityGroup:
     Type: AWS::EC2::SecurityGroup
-    Properties: 
-      GroupDescription: Security group with no rules
-      GroupName: SSM-Security-group
+    Properties:
+      GroupDescription: >
+        No inbound rules, deliberately. Session Manager works outbound-only, which is the whole
+        point of this template: no port 22 open anywhere and no key pair.
+      # No GroupName either, for the same reason as RoleName.
+      VpcId: !Ref VpcId
+      SecurityGroupEgress:
+        # Made explicit. Omitting egress does not mean "none": CloudFormation applies the
+        # default allow-all rule, so the previous version was permitting all outbound traffic
+        # without saying so. It still is, because the agent needs to reach the SSM endpoints,
+        # but now that is a stated decision rather than a default.
+        - IpProtocol: -1
+          CidrIp: 0.0.0.0/0
+          Description: Outbound to the SSM endpoints. Narrow this to VPC endpoints if required.
 
   EC2Instance:
     Type: AWS::EC2::Instance
-    Properties: 
-      ImageId: ami-0323c3dd2da7fb37d
-      InstanceType: t2.micro
+    Properties:
+      ImageId: !Ref LatestAmiId
+      InstanceType: !Ref InstanceType
       IamInstanceProfile: !Ref EC2InstanceProfile
+      SubnetId: !Ref SubnetId
       SecurityGroupIds:
-        - Ref: EC2SecurityGroup
+        - !Ref EC2SecurityGroup
       Tags:
         - Key: Name
           Value: SSM-EC2
@@ -51,16 +102,24 @@ Resources:
           - Effect: Allow
             Principal:
               AWS:
-              - !Sub arn:aws:iam::${AWS::AccountId}:root
+                - !Sub arn:aws:iam::${AWS::AccountId}:root
             Action:
-              - 'sts:AssumeRole'
+              - sts:AssumeRole
+            Condition:
+              # Added. `Principal: root` trusts EVERY identity in the account, so without a
+              # condition any user or role with sts:AssumeRole could take this role. Requiring
+              # MFA is the same control the sibling IAM-role-for-users/test-trust-policy.json
+              # already applies, so this repository was inconsistent with itself.
+              Bool:
+                aws:MultiFactorAuthPresent: 'true'
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess
+        # AmazonEC2ReadOnlyAccess was attached and is broader than this role needs: it grants
+        # read access to every EC2 resource in the account. The role only has to find the one
+        # instance it will connect to, which the inline policy below covers, so it is dropped.
         - arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess
       Path: /
-      RoleName: IAMroleToLoginIntoInstance
       Policies:
-        - PolicyName: IAMroleToLoginIntoInstanceSessionManager
+        - PolicyName: SessionManagerAccess
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -68,5 +127,31 @@ Resources:
                 Action: ssm:StartSession
                 Resource: !Sub arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/${EC2Instance}
               - Effect: Allow
-                Action: ssm:TerminateSession
+                Action:
+                  - ssm:TerminateSession
+                  - ssm:ResumeSession
+                # NOT wrapped in !Sub, deliberately. `${aws:username}` is an IAM policy
+                # variable that IAM expands at evaluation time, so it has to reach IAM as a
+                # literal. Adding !Sub here makes CloudFormation try to resolve it and fail the
+                # stack with "variable aws:username not found".
                 Resource: arn:aws:ssm:*:*:session/${aws:username}-*
+              - Effect: Allow
+                Action:
+                  - ec2:DescribeInstances
+                  - ssm:DescribeInstanceInformation
+                  - ssm:DescribeSessions
+                  - ssm:GetConnectionStatus
+                # These four are not resource-scopable: AWS defines them without a resource
+                # type, so a narrower ARN would deny rather than restrict. They are read-only.
+                Resource: '*'
+
+Outputs:
+  InstanceId:
+    Value: !Ref EC2Instance
+    Description: Instance to connect to with `aws ssm start-session --target <id>`.
+  LoginRoleArn:
+    Value: !GetAtt IAMroleToLoginIntoInstance.Arn
+    Description: Role to assume in order to start a session. Requires MFA.
+  ResolvedAmiId:
+    Value: !Ref LatestAmiId
+    Description: The AMI the SSM parameter resolved to at deploy time.

--- a/cloudtrail-S3PolicyForCloudTrail.json
+++ b/cloudtrail-S3PolicyForCloudTrail.json
@@ -21,7 +21,7 @@
           ]
         },
         "Action": "s3:PutObject",
-        "Resource": "arn:aws:s3:::your-trail-logs-bucket00112233/AWSLogs/your-admin-account-id/*",
+        "Resource": "arn:aws:s3:::your-trail-logs-bucket00112233/AWSLogs/YOUR-ACCOUNT-ID/*",
         "Condition": {
           "StringEquals": {
             "s3:x-amz-acl": "bucket-owner-full-control"

--- a/cloudtrail.md
+++ b/cloudtrail.md
@@ -59,7 +59,7 @@ cloudtrail-S3PolicyForCloudTrail.json
         ]
       },
       "Action": "s3:PutObject",
-      "Resource": "arn:aws:s3:::your-trail-logs-bucket00112233/AWSLogs/your-admin-account-id/*",
+      "Resource": "arn:aws:s3:::your-trail-logs-bucket00112233/AWSLogs/YOUR-ACCOUNT-ID/*",
       "Condition": {
         "StringEquals": {
           "s3:x-amz-acl": "bucket-owner-full-control"
@@ -72,7 +72,7 @@ cloudtrail-S3PolicyForCloudTrail.json
 
 *Notes:*
 * your-trail-logs-bucket00112233 -> bucket
-* your-admin-account-id -> account id (master account)
+* YOUR-ACCOUNT-ID -> account id (master account)
 
 *More info:* https://docs.aws.amazon.com/awscloudtrail/latest/userguide/create-s3-bucket-policy-for-cloudtrail.html
 

--- a/cloudwatch-alarms-billing-CloudWatchMetricsPolicyForBilling.json
+++ b/cloudwatch-alarms-billing-CloudWatchMetricsPolicyForBilling.json
@@ -2,17 +2,25 @@
   "Version": "2012-10-17",
   "Statement": [
     {
+      "Sid": "MetricsHaveNoResourceType",
+      "Effect": "Allow",
       "Action": [
         "cloudwatch:GetMetricStatistics",
         "cloudwatch:ListMetrics",
-        "cloudwatch:PutMetricData",
+        "cloudwatch:PutMetricData"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "AlarmsScopedToTheBillingAlarm",
+      "Effect": "Allow",
+      "Action": [
         "cloudwatch:PutMetricAlarm",
-        "cloudwatch:SetAlarmState",
         "cloudwatch:DescribeAlarms",
+        "cloudwatch:SetAlarmState",
         "cloudwatch:DeleteAlarms"
       ],
-      "Effect": "Allow",
-      "Resource": "*"
+      "Resource": "arn:aws:cloudwatch:us-east-1:YOUR-ACCOUNT-ID:alarm:billing-*"
     }
   ]
 }

--- a/cloudwatch-alarms-billing-SNSCreateAndManageTopics.json
+++ b/cloudwatch-alarms-billing-SNSCreateAndManageTopics.json
@@ -2,14 +2,20 @@
   "Version": "2012-10-17",
   "Statement": [
     {
+      "Sid": "ListIsNotResourceScopable",
+      "Effect": "Allow",
+      "Action": "sns:ListTopics",
+      "Resource": "*"
+    },
+    {
+      "Sid": "ManageOnlyTheBillingTopic",
       "Effect": "Allow",
       "Action": [
         "sns:CreateTopic",
-        "sns:ListTopics",
         "sns:SetTopicAttributes",
         "sns:DeleteTopic"
       ],
-      "Resource": "*"
+      "Resource": "arn:aws:sns:us-east-1:YOUR-ACCOUNT-ID:billing-*"
     }
   ]
 }

--- a/cloudwatch-alarms-billing.md
+++ b/cloudwatch-alarms-billing.md
@@ -72,15 +72,15 @@ cloudwatch-alarms-billing-SNSCreateAndManageTopics.json
 ## Add policies to group
 
 ```shell
-aws iam attach-group-policy --policy-arn arn:aws:iam::your-admin-account-id:policy/CloudWatchMetricsPolicyForBilling --group-name Reviewers
+aws iam attach-group-policy --policy-arn arn:aws:iam::YOUR-ACCOUNT-ID:policy/CloudWatchMetricsPolicyForBilling --group-name Reviewers
 
-aws iam attach-group-policy --policy-arn arn:aws:iam::your-admin-account-id:policy/SNSCreateAndManageTopics --group-name Reviewers
+aws iam attach-group-policy --policy-arn arn:aws:iam::YOUR-ACCOUNT-ID:policy/SNSCreateAndManageTopics --group-name Reviewers
 ```
 
 If we need to make a change in the policies, we have to create a new version (up to 5)
 Example:
 ```shell
-aws iam create-policy-version --policy-arn arn:aws:iam::your-admin-account-id:policy/CloudWatchMetricsPolicyForBilling --policy-document file://cloudwatch-alarms-billing-CloudWatchMetricsPolicyForBilling.json --set-as-default
+aws iam create-policy-version --policy-arn arn:aws:iam::YOUR-ACCOUNT-ID:policy/CloudWatchMetricsPolicyForBilling --policy-document file://cloudwatch-alarms-billing-CloudWatchMetricsPolicyForBilling.json --set-as-default
 ```
 
 ## Create users and provide proper access
@@ -112,14 +112,14 @@ This will return our topic's ARN:
 
 ```shell
 {
-    "TopicArn": "arn:aws:sns:us-east-1:your-admin-account-id:billing-alarm-topic"
+    "TopicArn": "arn:aws:sns:us-east-1:YOUR-ACCOUNT-ID:billing-alarm-topic"
 }
 ```
 
 ### Subscribe to that topic
 
 ```shell
-aws sns subscribe --topic-arn arn:aws:sns:us-east-1:your-admin-account-id:billing-alarm-topic \
+aws sns subscribe --topic-arn arn:aws:sns:us-east-1:YOUR-ACCOUNT-ID:billing-alarm-topic \
   --protocol email \
   --notification-endpoint your-email@email.com
 ```
@@ -140,14 +140,14 @@ Alternatively, you can check with the cli the current status of your subscriptio
 
 ```shell
 aws sns list-subscriptions-by-topic \
-  --topic-arn arn:aws:sns:us-east-1:your-admin-account-id:billing-alarm-topic
+  --topic-arn arn:aws:sns:us-east-1:YOUR-ACCOUNT-ID:billing-alarm-topic
 ```
 
 To be sure everything is working as expected we can publish a message to that topic.
 
 ```shell
 aws sns publish --message "Testing" \
-  --topic arn:aws:sns:us-east-1:your-admin-account-id:billing-alarm-topic
+  --topic arn:aws:sns:us-east-1:YOUR-ACCOUNT-ID:billing-alarm-topic
 ```
 
 You should receive an email like this:
@@ -174,6 +174,6 @@ aws cloudwatch put-metric-alarm --alarm-name aws-billing-alarm \
   --period 21600 \
   --evaluation-periods 1 \
   --treat-missing-data missing \
-  --alarm-actions arn:aws:sns:us-east-1:your-admin-account-id:billing-alarm-topic \
+  --alarm-actions arn:aws:sns:us-east-1:YOUR-ACCOUNT-ID:billing-alarm-topic \
   --dimensions "Name=Currency,Value=USD"
 ```

--- a/encryption/README.md
+++ b/encryption/README.md
@@ -19,7 +19,7 @@ Example output:
 {
   "KeyMetadata": {
     "Origin": "AWS_KMS",
-    "KeyId": "c9bd0eb7-cfe7-4e88-ad8d-12d130ce199d",
+    "KeyId": "YOUR-KMS-KEY-ID",
     "Description": "Development test key",
     "KeyManager": "CUSTOMER",
     "EncryptionAlgorithms": ["SYMMETRIC_DEFAULT"],
@@ -28,7 +28,7 @@ Example output:
     "KeyUsage": "ENCRYPT_DECRYPT",
     "KeyState": "Enabled",
     "CreationDate": 1593389383.576,
-    "Arn": "arn:aws:kms:us-east-1:YOUR-ACCOUNT-ID:key/c9bd0eb7-cfe7-4e88-ad8d-12d130ce199d",
+    "Arn": "arn:aws:kms:us-east-1:YOUR-ACCOUNT-ID:key/YOUR-KMS-KEY-ID",
     "AWSAccountId": "YOUR-ACCOUNT-ID"
   }
 }
@@ -39,7 +39,7 @@ Example output:
 ```shell
 aws kms put-key-policy \
     --policy-name default \
-    --key-id c9bd0eb7-cfe7-4e88-ad8d-12d130ce199d \
+    --key-id YOUR-KMS-KEY-ID \
     --policy file://key-policy.json
 ```
 
@@ -95,7 +95,7 @@ Example output:
 _Hint_: we are using server-side encryption with KMS, specifying a KMS customer master key (CMK)
 
 ```shell
-aws s3 cp hello-world.txt s3://YOUR-BUCKET-NAME/ --sse aws:kms --sse-kms-key-id c9bd0eb7-cfe7-4e88-ad8d-12d130ce199d
+aws s3 cp hello-world.txt s3://YOUR-BUCKET-NAME/ --sse aws:kms --sse-kms-key-id YOUR-KMS-KEY-ID
 ```
 
 Example output:
@@ -120,12 +120,12 @@ Example output:
   "ContentLength": 12,
   "ETag": "\"5c962486475d8e4ac65d9495274b1a9d\"",
   "ServerSideEncryption": "aws:kms",
-  "SSEKMSKeyId": "arn:aws:kms:us-east-1:YOUR-ACCOUNT-ID:key/c9bd0eb7-cfe7-4e88-ad8d-12d130ce199d",
+  "SSEKMSKeyId": "arn:aws:kms:us-east-1:YOUR-ACCOUNT-ID:key/YOUR-KMS-KEY-ID",
   "Metadata": {}
 }
 ```
 
-Great! We can see that Server Side Encryption is using `aws:kms` with the key that we provided: `arn:aws:kms:us-east-1:YOUR-ACCOUNT-ID:key/c9bd0eb7-cfe7-4e88-ad8d-12d130ce199d`
+Great! We can see that Server Side Encryption is using `aws:kms` with the key that we provided: `arn:aws:kms:us-east-1:YOUR-ACCOUNT-ID:key/YOUR-KMS-KEY-ID`
 
 **With this, only AWS users/roles that have permissions to use this KMS key will be able to read the object from S3.**
 
@@ -184,7 +184,7 @@ Note: We are going to use the smallest window period, 7 days.
 
 ```shell
 aws kms schedule-key-deletion \
-    --key-id arn:aws:kms:us-east-1:YOUR-ACCOUNT-ID:key/c9bd0eb7-cfe7-4e88-ad8d-12d130ce199d \
+    --key-id arn:aws:kms:us-east-1:YOUR-ACCOUNT-ID:key/YOUR-KMS-KEY-ID \
     --pending-window-in-days 7
 ```
 
@@ -192,7 +192,7 @@ Example output:
 
 ```json
 {
-  "KeyId": "arn:aws:kms:us-east-1:YOUR-ACCOUNT-ID:key/c9bd0eb7-cfe7-4e88-ad8d-12d130ce199d",
+  "KeyId": "arn:aws:kms:us-east-1:YOUR-ACCOUNT-ID:key/YOUR-KMS-KEY-ID",
   "DeletionDate": 1594080000.0
 }
 ```

--- a/encryption/README.md
+++ b/encryption/README.md
@@ -125,7 +125,7 @@ Example output:
 }
 ```
 
-Great! We can see that Server Side Encryption is using `aws:kms` with the key that we provided: `arn:aws:kms:us-east-1:YOUR-ACCOUNT-ID:key/YOUR-KMS-KEY-ID`
+Great! We can see that server-side encryption is using `aws:kms` with the key that we provided: `arn:aws:kms:us-east-1:YOUR-ACCOUNT-ID:key/YOUR-KMS-KEY-ID`
 
 **With this, only AWS users/roles that have permissions to use this KMS key will be able to read the object from S3.**
 

--- a/encryption/README.md
+++ b/encryption/README.md
@@ -28,8 +28,8 @@ Example output:
     "KeyUsage": "ENCRYPT_DECRYPT",
     "KeyState": "Enabled",
     "CreationDate": 1593389383.576,
-    "Arn": "arn:aws:kms:us-east-1:your-aws-account-id:key/c9bd0eb7-cfe7-4e88-ad8d-12d130ce199d",
-    "AWSAccountId": "your-aws-account-id"
+    "Arn": "arn:aws:kms:us-east-1:YOUR-ACCOUNT-ID:key/c9bd0eb7-cfe7-4e88-ad8d-12d130ce199d",
+    "AWSAccountId": "YOUR-ACCOUNT-ID"
   }
 }
 ```
@@ -48,14 +48,14 @@ _Note_: we are setting `your-user` as the `Administrator` and the only one with 
 ## Create S3 bucket with server-side encryption enabled
 
 ```shell
-aws s3api create-bucket --bucket my-bucket-8200334565 --region us-east-1
+aws s3api create-bucket --bucket YOUR-BUCKET-NAME --region us-east-1
 ```
 
 Example output:
 
 ```shell
 {
-    "Location": "/my-bucket-8200334565"
+    "Location": "/YOUR-BUCKET-NAME"
 }
 ```
 
@@ -63,7 +63,7 @@ Example output:
 
 ```shell
 aws s3api put-bucket-encryption \
-    --bucket my-bucket-8200334565 \
+    --bucket YOUR-BUCKET-NAME \
     --server-side-encryption-configuration '{"Rules": [{"ApplyServerSideEncryptionByDefault": {"SSEAlgorithm": "AES256"}}]}'
 ```
 
@@ -71,7 +71,7 @@ We can check the server-side encryption configuration...
 
 ```shell
 aws s3api get-bucket-encryption \
-    --bucket my-bucket-8200334565
+    --bucket YOUR-BUCKET-NAME
 ```
 
 Example output:
@@ -95,19 +95,19 @@ Example output:
 _Hint_: we are using server-side encryption with KMS, specifying a KMS customer master key (CMK)
 
 ```shell
-aws s3 cp hello-world.txt s3://my-bucket-8200334565/ --sse aws:kms --sse-kms-key-id c9bd0eb7-cfe7-4e88-ad8d-12d130ce199d
+aws s3 cp hello-world.txt s3://YOUR-BUCKET-NAME/ --sse aws:kms --sse-kms-key-id c9bd0eb7-cfe7-4e88-ad8d-12d130ce199d
 ```
 
 Example output:
 
 ```shell
-upload: ./hello-world.txt to s3://my-bucket-8200334565/hello-world.txt
+upload: ./hello-world.txt to s3://YOUR-BUCKET-NAME/hello-world.txt
 ```
 
 Let's check the metadata of the uploaded object:
 
 ```shell
-aws s3api head-object --bucket my-bucket-8200334565 --key hello-world.txt
+aws s3api head-object --bucket YOUR-BUCKET-NAME --key hello-world.txt
 ```
 
 Example output:
@@ -120,37 +120,37 @@ Example output:
   "ContentLength": 12,
   "ETag": "\"5c962486475d8e4ac65d9495274b1a9d\"",
   "ServerSideEncryption": "aws:kms",
-  "SSEKMSKeyId": "arn:aws:kms:us-east-1:your-aws-account-id:key/c9bd0eb7-cfe7-4e88-ad8d-12d130ce199d",
+  "SSEKMSKeyId": "arn:aws:kms:us-east-1:YOUR-ACCOUNT-ID:key/c9bd0eb7-cfe7-4e88-ad8d-12d130ce199d",
   "Metadata": {}
 }
 ```
 
-Great! We can see that Server Side Encryption is using `aws:kms` with the key that we provided: `arn:aws:kms:us-east-1:your-aws-account-id:key/c9bd0eb7-cfe7-4e88-ad8d-12d130ce199d`
+Great! We can see that Server Side Encryption is using `aws:kms` with the key that we provided: `arn:aws:kms:us-east-1:YOUR-ACCOUNT-ID:key/c9bd0eb7-cfe7-4e88-ad8d-12d130ce199d`
 
 **With this, only AWS users/roles that have permissions to use this KMS key will be able to read the object from S3.**
 
 Try:
 
 ```shel
-aws s3 cp s3://my-bucket-8200334565/hello-world.txt .
+aws s3 cp s3://YOUR-BUCKET-NAME/hello-world.txt .
 ```
 
 Example output:
 
 ```
-download: s3://my-bucket-8200334565/hello-world.txt to ./hello-world.txt
+download: s3://YOUR-BUCKET-NAME/hello-world.txt to ./hello-world.txt
 ```
 
 Now, switch to any other user and try again...
 
 ```shel
-aws s3 cp s3://my-bucket-8200334565/hello-world.txt .
+aws s3 cp s3://YOUR-BUCKET-NAME/hello-world.txt .
 ```
 
 Example output:
 
-```shell
-download failed: s3://my-bucket-8200334565/hello-world.txt to ./hello-world.txt An error occurred (AccessDenied) when calling the GetObject operation: Access Denied
+```text
+download failed: s3://YOUR-BUCKET-NAME/hello-world.txt to ./hello-world.txt An error occurred (AccessDenied) when calling the GetObject operation: Access Denied
 ```
 
 Everything works as expected!
@@ -163,13 +163,13 @@ First we need to `empty1` the bucket.
 We are going to recursively delete all its objects
 
 ```shell
-aws s3 rm --recursive s3://my-bucket-8200334565/
+aws s3 rm --recursive s3://YOUR-BUCKET-NAME/
 ```
 
 Now we can delete the bucket:
 
 ```shell
-aws s3api delete-bucket --bucket my-bucket-8200334565 --region us-east-1
+aws s3api delete-bucket --bucket YOUR-BUCKET-NAME --region us-east-1
 ```
 
 We can also use this short-cut to empty and delete:
@@ -184,7 +184,7 @@ Note: We are going to use the smallest window period, 7 days.
 
 ```shell
 aws kms schedule-key-deletion \
-    --key-id arn:aws:kms:us-east-1:your-aws-account-id:key/c9bd0eb7-cfe7-4e88-ad8d-12d130ce199d \
+    --key-id arn:aws:kms:us-east-1:YOUR-ACCOUNT-ID:key/c9bd0eb7-cfe7-4e88-ad8d-12d130ce199d \
     --pending-window-in-days 7
 ```
 
@@ -192,7 +192,7 @@ Example output:
 
 ```json
 {
-  "KeyId": "arn:aws:kms:us-east-1:your-aws-account-id:key/c9bd0eb7-cfe7-4e88-ad8d-12d130ce199d",
+  "KeyId": "arn:aws:kms:us-east-1:YOUR-ACCOUNT-ID:key/c9bd0eb7-cfe7-4e88-ad8d-12d130ce199d",
   "DeletionDate": 1594080000.0
 }
 ```

--- a/encryption/application/README.md
+++ b/encryption/application/README.md
@@ -31,7 +31,7 @@ Example output:
         "CreateDate": "2020-06-29T21:19:00Z", 
         "RoleName": "encryption-lambda-read", 
         "Path": "/", 
-        "Arn": "arn:aws:iam::your-aws-account-id:role/encryption-lambda-read"
+        "Arn": "arn:aws:iam::YOUR-ACCOUNT-ID:role/encryption-lambda-read"
     }
 }
 
@@ -64,7 +64,7 @@ Example output:
 {
     "KeyMetadata": {
         "Origin": "AWS_KMS", 
-        "KeyId": "c556d894-361e-437a-8890-e70fa95a835c", 
+        "KeyId": "YOUR-KMS-KEY-ID", 
         "Description": "Development test key", 
         "KeyManager": "CUSTOMER", 
         "EncryptionAlgorithms": [
@@ -75,8 +75,8 @@ Example output:
         "KeyUsage": "ENCRYPT_DECRYPT", 
         "KeyState": "Enabled", 
         "CreationDate": 1593465813.221, 
-        "Arn": "arn:aws:kms:us-east-1:your-aws-account-id:key/c556d894-361e-437a-8890-e70fa95a835c", 
-        "AWSAccountId": "your-aws-account-id"
+        "Arn": "arn:aws:kms:us-east-1:YOUR-ACCOUNT-ID:key/YOUR-KMS-KEY-ID", 
+        "AWSAccountId": "YOUR-ACCOUNT-ID"
     }
 }
 ```
@@ -88,7 +88,7 @@ Example output:
 ```shell
 aws kms create-alias \
     --alias-name alias/encryption-test \
-    --target-key-id c556d894-361e-437a-8890-e70fa95a835c
+    --target-key-id YOUR-KMS-KEY-ID
 ```
 
 ## Change key policy
@@ -96,21 +96,21 @@ aws kms create-alias \
 ```shell
 aws kms put-key-policy \
     --policy-name default \
-    --key-id c556d894-361e-437a-8890-e70fa95a835c \
+    --key-id YOUR-KMS-KEY-ID \
     --policy file://key-policy.json
 ```
 
 ## Create S3 bucket with server-side encryption enabled
 
 ```shell
-aws s3api create-bucket --bucket my-bucket-8200334565 --region us-east-1
+aws s3api create-bucket --bucket YOUR-BUCKET-NAME --region us-east-1
 ```
 
 Example output:
 
 ```shell
 {
-    "Location": "/my-bucket-8200334565"
+    "Location": "/YOUR-BUCKET-NAME"
 }
 ```
 
@@ -118,7 +118,7 @@ Example output:
 
 ```shell
 aws s3api put-bucket-encryption \
-    --bucket my-bucket-8200334565 \
+    --bucket YOUR-BUCKET-NAME \
     --server-side-encryption-configuration '{"Rules": [{"ApplyServerSideEncryptionByDefault": {"SSEAlgorithm": "AES256"}}]}'
 ```
 
@@ -126,7 +126,7 @@ We can check the server-side encryption configuration...
 
 ```shell
 aws s3api get-bucket-encryption \
-    --bucket my-bucket-8200334565
+    --bucket YOUR-BUCKET-NAME
 ```
 
 Example output:
@@ -156,7 +156,7 @@ aws lambda create-function \
     --runtime nodejs12.x \
     --zip-file fileb://encryption-lambda-write.zip \
     --handler encryption-lambda-write.handler \
-    --role arn:aws:iam::your-aws-account-id:role/encryption-lambda-write
+    --role arn:aws:iam::YOUR-ACCOUNT-ID:role/encryption-lambda-write
 
 ```
 
@@ -174,7 +174,7 @@ aws lambda create-function \
     --runtime nodejs12.x \
     --zip-file fileb://encryption-lambda-read.zip \
     --handler encryption-lambda-read.handler \
-    --role arn:aws:iam::your-aws-account-id:role/encryption-lambda-read
+    --role arn:aws:iam::YOUR-ACCOUNT-ID:role/encryption-lambda-read
 ```
 
 Then, zip your lambda:
@@ -219,21 +219,21 @@ Note: We are going to use the smallest window period, 7 days.
 
 ```shell
 aws kms schedule-key-deletion \
-    --key-id arn:aws:kms:us-east-1:your-aws-account-id:key/c556d894-361e-437a-8890-e70fa95a835c \
+    --key-id arn:aws:kms:us-east-1:YOUR-ACCOUNT-ID:key/YOUR-KMS-KEY-ID \
     --pending-window-in-days 7
 ```
 
 ### Delete S3 bucket
 
 ```shell
-aws s3 rb --force s3://my-bucket-8200334565
+aws s3 rb --force s3://YOUR-BUCKET-NAME
 ```
 
 Example output:
 
 ```shell
-delete: s3://my-bucket-8200334565/hello-world.txt
-remove_bucket: my-bucket-8200334565
+delete: s3://YOUR-BUCKET-NAME/hello-world.txt
+remove_bucket: YOUR-BUCKET-NAME
 ```
 
 ### Delete Lambdas

--- a/encryption/application/encryption-lambda-read-S3-getObject-policy.json
+++ b/encryption/application/encryption-lambda-read-S3-getObject-policy.json
@@ -4,10 +4,9 @@
     {
       "Effect": "Allow",
       "Action": [
-        "s3:GetObject",
-        "s3:GetObjectAcl"
+        "s3:GetObject"
       ],
-      "Resource": "arn:aws:s3:::my-bucket-8200334565/*"
+      "Resource": "arn:aws:s3:::YOUR-BUCKET-NAME/*"
     }
   ]
 }

--- a/encryption/application/encryption-lambda-read.js
+++ b/encryption/application/encryption-lambda-read.js
@@ -1,20 +1,57 @@
 const AWS = require('aws-sdk');
 const s3 = new AWS.S3();
 
-exports.handler = async (event) => {
+// The bucket and key come from the environment rather than being hardcoded. The previous
+// version embedded a specific bucket name in the source, which meant the function only worked
+// against one account's bucket and the name had to be edited to reuse the demo.
+const BUCKET = process.env.BUCKET_NAME;
+const KEY = process.env.OBJECT_KEY || 'hello-world.txt';
 
-  const bucketName = 'my-bucket-8200334565';
-  const keyName = 'hello-world.txt';
-
-  const params = {
-    'Bucket': bucketName,
-    'Key': keyName
-  };
-
-  try {
-    const data = await s3.getObject(params).promise();
-    console.log(data.Body.toString('utf-8'))
-  } catch (err) {
-    console.log(err)
+exports.handler = async () => {
+  if (!BUCKET) {
+    // Configuration errors are thrown, not logged and ignored. See the note on errors below.
+    throw new Error('BUCKET_NAME is not set');
   }
-}
+
+  const params = { Bucket: BUCKET, Key: KEY };
+
+  let data;
+  try {
+    data = await s3.getObject(params).promise();
+  } catch (err) {
+    // Rethrown, not swallowed. The previous version did `console.log(err)` and returned
+    // undefined, so a missing object, a denied kms:Decrypt or a wrong bucket all produced a
+    // SUCCESSFUL Lambda invocation with nothing to show for it. A thrown error is what makes
+    // the invocation fail, retry per the function's configuration, and appear in metrics.
+    //
+    // Only the error's name and code are logged. An AWS SDK error message can carry the
+    // bucket, the key and the full request, and this function exists to demonstrate keeping
+    // data confidential.
+    console.error(`getObject failed: ${err.name} (code: ${err.code})`);
+    throw err;
+  }
+
+  // The point of this demo is that the object is encrypted at rest with KMS and that this role
+  // is allowed to decrypt it. Proving that does NOT require printing the plaintext.
+  //
+  // The previous version did `console.log(data.Body.toString('utf-8'))`, which wrote the
+  // decrypted content into CloudWatch Logs. Logs are a different security boundary from the
+  // bucket: they are not encrypted with the same key, they are readable by anyone with
+  // logs:FilterLogEvents, and they persist independently of the object. So a demo about
+  // encryption at rest was quietly defeating itself in its last line.
+  //
+  // What is logged instead is enough to show the decryption worked: the SSE algorithm S3
+  // reports, the KMS key it used, and the size of what came back.
+  console.log(
+    `decrypted ${data.ContentLength} bytes from s3://${BUCKET}/${KEY} ` +
+      `(sse: ${data.ServerSideEncryption || 'none'}, kms key: ${data.SSEKMSKeyId ? 'present' : 'none'})`
+  );
+
+  // Returned rather than logged, so a caller can assert on it without the content touching
+  // the log group.
+  return {
+    bytes: data.ContentLength,
+    serverSideEncryption: data.ServerSideEncryption || null,
+    body: data.Body.toString('utf-8')
+  };
+};

--- a/encryption/application/encryption-lambda-write-S3-putObject-policy.json
+++ b/encryption/application/encryption-lambda-write-S3-putObject-policy.json
@@ -4,10 +4,9 @@
     {
       "Effect": "Allow",
       "Action": [
-        "s3:PutObject",
-        "s3:PutObjectAcl"
+        "s3:PutObject"
       ],
-      "Resource": "arn:aws:s3:::my-bucket-8200334565/*"
+      "Resource": "arn:aws:s3:::YOUR-BUCKET-NAME/*"
     }
   ]
 }

--- a/encryption/application/encryption-lambda-write.js
+++ b/encryption/application/encryption-lambda-write.js
@@ -1,23 +1,44 @@
 const AWS = require('aws-sdk');
 const s3 = new AWS.S3();
 
-exports.handler = async (event) => {
+// From the environment, not hardcoded. The KMS key in particular was a specific key ARN in the
+// source, which is account- and region-specific and cannot be reused.
+const BUCKET = process.env.BUCKET_NAME;
+const KEY = process.env.OBJECT_KEY || 'hello-world.txt';
+const KMS_KEY_ID = process.env.KMS_KEY_ID;
+const CONTENT = process.env.OBJECT_BODY || 'Hello World!';
 
-  const bucketName = 'my-bucket-8200334565';
-  const keyName = 'hello-world.txt';
-  const content = 'Hello World!';
+exports.handler = async () => {
+  if (!BUCKET) throw new Error('BUCKET_NAME is not set');
+  if (!KMS_KEY_ID) {
+    // Deliberately fatal. Without SSEKMSKeyId, S3 falls back to the bucket's default
+    // encryption, so a missing key id would silently write the object with different (or no)
+    // encryption than this demo claims to be showing.
+    throw new Error('KMS_KEY_ID is not set, and this demo is specifically about SSE-KMS');
+  }
 
   const params = {
-    'Bucket': bucketName,
-    'Key': keyName,
-    'Body': content,
-    'ServerSideEncryption': 'aws:kms',
-    'SSEKMSKeyId': 'arn:aws:kms:us-east-1:your-aws-account-id:key/c556d894-361e-437a-8890-e70fa95a835c'
+    Bucket: BUCKET,
+    Key: KEY,
+    Body: CONTENT,
+    ServerSideEncryption: 'aws:kms',
+    SSEKMSKeyId: KMS_KEY_ID
   };
 
+  let result;
   try {
-    const data = await s3.putObject(params).promise();
+    result = await s3.putObject(params).promise();
   } catch (err) {
-    console.log(err)
+    // Rethrown for the same reason as the read function: the previous version logged the error
+    // and returned undefined, so a denied kms:GenerateDataKey or a missing bucket produced a
+    // successful invocation that had written nothing. Only name and code are logged, because an
+    // SDK error message can carry the bucket and key.
+    console.error(`putObject failed: ${err.name} (code: ${err.code})`);
+    throw err;
   }
-}
+
+  // The previous version assigned the result to `data` and never used it.
+  console.log(`wrote s3://${BUCKET}/${KEY} encrypted with aws:kms (etag: ${result.ETag})`);
+
+  return { etag: result.ETag, serverSideEncryption: 'aws:kms' };
+};

--- a/encryption/application/key-policy.json
+++ b/encryption/application/key-policy.json
@@ -6,7 +6,7 @@
       "Sid": "Allow access for Key Administrators",
       "Effect": "Allow",
       "Principal": {
-        "AWS": "arn:aws:iam::your-aws-account-id:user/your-user"
+        "AWS": "arn:aws:iam::YOUR-ACCOUNT-ID:user/your-user"
       },
       "Action": [
         "kms:Create*",
@@ -31,9 +31,9 @@
       "Effect": "Allow",
       "Principal": {
         "AWS": [
-          "arn:aws:iam::your-aws-account-id:user/your-user",
-          "arn:aws:iam::your-aws-account-id:role/encryption-lambda-write",
-          "arn:aws:iam::your-aws-account-id:role/encryption-lambda-read"
+          "arn:aws:iam::YOUR-ACCOUNT-ID:user/your-user",
+          "arn:aws:iam::YOUR-ACCOUNT-ID:role/encryption-lambda-write",
+          "arn:aws:iam::YOUR-ACCOUNT-ID:role/encryption-lambda-read"
         ]
       },
       "Action": [
@@ -49,7 +49,7 @@
       "Sid": "Allow attachment of persistent resources",
       "Effect": "Allow",
       "Principal": {
-        "AWS": "arn:aws:iam::your-aws-account-id:user/your-user"
+        "AWS": "arn:aws:iam::YOUR-ACCOUNT-ID:user/your-user"
       },
       "Action": [
         "kms:CreateGrant",

--- a/encryption/key-policy.json
+++ b/encryption/key-policy.json
@@ -6,7 +6,7 @@
           "Sid": "Allow access for Key Administrators",
           "Effect": "Allow",
           "Principal": {
-              "AWS": "arn:aws:iam::your-aws-account-id:user/your-user"
+              "AWS": "arn:aws:iam::YOUR-ACCOUNT-ID:user/your-user"
           },
           "Action": [
               "kms:Create*",
@@ -30,7 +30,7 @@
           "Sid": "Allow use of the key",
           "Effect": "Allow",
           "Principal": {
-              "AWS": "arn:aws:iam::your-aws-account-id:user/your-user"
+              "AWS": "arn:aws:iam::YOUR-ACCOUNT-ID:user/your-user"
           },
           "Action": [
               "kms:Encrypt",
@@ -45,7 +45,7 @@
           "Sid": "Allow attachment of persistent resources",
           "Effect": "Allow",
           "Principal": {
-              "AWS": "arn:aws:iam::your-aws-account-id:user/your-user"
+              "AWS": "arn:aws:iam::YOUR-ACCOUNT-ID:user/your-user"
           },
           "Action": [
               "kms:CreateGrant",

--- a/security/.gitignore
+++ b/security/.gitignore
@@ -1,1 +1,0 @@
-cloudsploit/scans

--- a/security/README.md
+++ b/security/README.md
@@ -1,5 +1,23 @@
 # Security
 
+> [!CAUTION]
+> **The infrastructure in this directory is deliberately insecure. Do not copy it.**
+>
+> This is a security training project: the templates exist so that the exercises can attack
+> them. `infrastructure/app.yml` opens `IpProtocol: -1` from `0.0.0.0/0` twice, plus SSH on 22,
+> and ports 5000 and 80, all to the entire internet. `infrastructure/s3.yml` creates three
+> buckets, one of them named `secret-recipes`, with no encryption at rest, no public-access
+> block and no versioning.
+>
+> None of that is an oversight and none of it has been fixed here, because the vulnerabilities
+> are the teaching material. The hardening exercise below deliberately fixes SSH inside
+> `sshd_config` on the running instance rather than in the template, so the template stays
+> vulnerable on purpose.
+>
+> If you have arrived here looking for a reference CloudFormation template, this is the
+> opposite of one.
+
+
 ## Deploying Infrastructure 
 
 ### S3 buckets
@@ -9,9 +27,9 @@ aws cloudformation create-stack --region us-east-1 --stack-name s3 --template-bo
 ```
 
 *S3 created...*
-S3BucketRecipesFree > cand-c3-free-recipes-your-aws-account-id
-S3BucketRecipesSecret > cand-c3-secret-recipes-your-aws-account-id
-S3BucketVPCFlowLogs > arn:aws:s3:::cand-c3-vpc-flow-logs-your-aws-account-id
+S3BucketRecipesFree > cand-c3-free-recipes-YOUR-ACCOUNT-ID
+S3BucketRecipesSecret > cand-c3-secret-recipes-YOUR-ACCOUNT-ID
+S3BucketVPCFlowLogs > arn:aws:s3:::cand-c3-vpc-flow-logs-YOUR-ACCOUNT-ID
 
 ### VPC and Subnets
 
@@ -34,9 +52,9 @@ You will need the public IP address of the attack instance from which to run the
 ## Upload data to S3 buckets 
 
 ```shell
-aws s3 cp resources/recipes/free_recipe.txt s3://cand-c3-free-recipes-your-aws-account-id/ --region us-east-1
+aws s3 cp resources/recipes/free_recipe.txt s3://cand-c3-free-recipes-YOUR-ACCOUNT-ID/ --region us-east-1
 
-aws s3 cp resources/recipes/secret_recipe.txt s3://cand-c3-secret-recipes-your-aws-account-id/ --region us-east-1
+aws s3 cp resources/recipes/secret_recipe.txt s3://cand-c3-secret-recipes-YOUR-ACCOUNT-ID/ --region us-east-1
 ```
 
 ## Test application
@@ -110,9 +128,9 @@ hydra -l ubuntu -P rockyou.txt ssh://ec2-23-23-34-174.compute-1.amazonaws.com
 Note: Still from the Attack instance
 
 ```shell
-aws s3 ls  s3://cand-c3-secret-recipes-your-aws-account-id/ --region us-east-1
+aws s3 ls  s3://cand-c3-secret-recipes-YOUR-ACCOUNT-ID/ --region us-east-1
 
-aws s3 cp s3://cand-c3-secret-recipes-your-aws-account-id/secret_recipe.txt  .  --region us-east-1
+aws s3 cp s3://cand-c3-secret-recipes-YOUR-ACCOUNT-ID/secret_recipe.txt  .  --region us-east-1
 
 cat secret_recipe.txt
 ```
@@ -210,7 +228,7 @@ hydra -l ubuntu -P rockyou.txt ssh://ec2-23-23-34-174.compute-1.amazonaws.com
 ```
 
 Expected output:
-```shell
+```text
 Hydra v8.6 (c) 2017 by van Hauser/THC - Please do not use in military or secret service organizations, or for illegal purposes.
 
 Hydra (http://www.thc.org/thc-hydra) starting at 2020-07-03 01:00:21
@@ -281,7 +299,7 @@ NEW policy:
     "Statement": [
         {
             "Action": "s3:GetObject",
-            "Resource": "arn:aws:s3:::cand-c3-free-recipes-your-aws-account-id/*",
+            "Resource": "arn:aws:s3:::cand-c3-free-recipes-YOUR-ACCOUNT-ID/*",
             "Effect": "Allow"
         }
     ]
@@ -301,13 +319,13 @@ ssh -i YourServiceClientKP.pem ubuntu@ec2-54-152-203-174.compute-1.amazonaws.com
 
 
 ```shell
-aws s3 ls  s3://cand-c3-secret-recipes-your-aws-account-id/ --region us-east-1
+aws s3 ls  s3://cand-c3-secret-recipes-YOUR-ACCOUNT-ID/ --region us-east-1
 
-aws s3 cp s3://cand-c3-secret-recipes-your-aws-account-id/secret_recipe.txt  .  --region us-east-1
+aws s3 cp s3://cand-c3-secret-recipes-YOUR-ACCOUNT-ID/secret_recipe.txt  .  --region us-east-1
 ```
 
 Expected output:
-```shell
+```text
 An error occurred (AccessDenied) when calling the ListObjects operation: Access Denied
 
 fatal error: An error occurred (403) when calling the HeadObject operation: Forbidden
@@ -317,7 +335,7 @@ fatal error: An error occurred (403) when calling the HeadObject operation: Forb
 
 ```shell
 aws s3api put-bucket-encryption \
-    --bucket cand-c3-secret-recipes-your-aws-account-id \
+    --bucket cand-c3-secret-recipes-YOUR-ACCOUNT-ID \
     --server-side-encryption-configuration '{"Rules": [{"ApplyServerSideEncryptionByDefault": {"SSEAlgorithm": "AES256"}}]}'
 ```
 

--- a/security/README.md
+++ b/security/README.md
@@ -4,8 +4,10 @@
 > **The infrastructure in this directory is deliberately insecure. Do not copy it.**
 >
 > This is a security training project: the templates exist so that the exercises can attack
-> them. `infrastructure/app.yml` opens `IpProtocol: -1` from `0.0.0.0/0` twice, plus SSH on 22,
-> and ports 5000 and 80, all to the entire internet. `infrastructure/s3.yml` creates three
+> them. `infrastructure/app.yml` opens all protocols inbound from `0.0.0.0/0` on the application
+> instance, plus SSH on 22, and ports 5000 and 80, all to the entire internet. (Four rules match
+> `IpProtocol: -1` with `0.0.0.0/0`, but only one is ingress; the other three are egress, which is
+> every security group's default and not an exposure.) `infrastructure/s3.yml` creates three
 > buckets, one of them named `secret-recipes`, with no encryption at rest, no public-access
 > block and no versioning.
 >

--- a/security/cloudsploit/README.md
+++ b/security/cloudsploit/README.md
@@ -21,7 +21,7 @@ Example output:
         "CreateDate": "2020-07-02T16:47:05Z", 
         "UserId": "AI*****Q**5R**********J4I", 
         "Path": "/", 
-        "Arn": "arn:aws:iam::your-aws-account-id:user/cloudsploit"
+        "Arn": "arn:aws:iam::YOUR-ACCOUNT-ID:user/cloudsploit"
     }
 }
 ```

--- a/security/infrastructure/app.yml
+++ b/security/infrastructure/app.yml
@@ -1,3 +1,13 @@
+# DELIBERATELY INSECURE. DO NOT COPY THIS TEMPLATE.
+#
+# This file is training material for a security exercise: the misconfigurations below are the
+# point of it, and the exercises in ../README.md attack them. Nothing here has been hardened.
+# See the caution block at the top of ../README.md.
+#
+# Specifically: two `IpProtocol: -1` rules from 0.0.0.0/0, which allow every protocol from
+# anywhere, plus SSH on 22 open to the internet, which is what the brute-force exercise
+# targets, plus 5000 and 80.
+#
 Description:  This template deploys ec2 instances for the project starter
 
 Parameters:

--- a/security/infrastructure/app.yml
+++ b/security/infrastructure/app.yml
@@ -4,9 +4,10 @@
 # point of it, and the exercises in ../README.md attack them. Nothing here has been hardened.
 # See the caution block at the top of ../README.md.
 #
-# Specifically: two `IpProtocol: -1` rules from 0.0.0.0/0, which allow every protocol from
-# anywhere, plus SSH on 22 open to the internet, which is what the brute-force exercise
-# targets, plus 5000 and 80.
+# Specifically: WebAppSG allows every protocol INBOUND from 0.0.0.0/0, plus SSH on 22 open to
+# the internet, which is what the brute-force exercise targets, plus 5000 and 80. Three further
+# `IpProtocol: -1` rules here are egress, which is the default for any security group and is not
+# an exposure; they are noted only so the ingress one is not lost among them.
 #
 Description:  This template deploys ec2 instances for the project starter
 

--- a/security/infrastructure/s3.yml
+++ b/security/infrastructure/s3.yml
@@ -1,3 +1,13 @@
+# DELIBERATELY INSECURE. DO NOT COPY THIS TEMPLATE.
+#
+# This file is training material for a security exercise: the misconfigurations below are the
+# point of it, and the exercises in ../README.md attack them. Nothing here has been hardened.
+# See the caution block at the top of ../README.md.
+#
+# Specifically: no BucketEncryption, no PublicAccessBlockConfiguration and no
+# VersioningConfiguration on any of the three buckets, one of which is named
+# `secret-recipes` and receives a file classified as confidential.
+#
 Description:  This template deploys an S3 bucket for storage of recipes.
 
 Resources:

--- a/security/infrastructure/vpc.yml
+++ b/security/infrastructure/vpc.yml
@@ -1,3 +1,11 @@
+# DELIBERATELY INSECURE. DO NOT COPY THIS TEMPLATE.
+#
+# This file is training material for a security exercise: the misconfigurations below are the
+# point of it, and the exercises in ../README.md attack them. Nothing here has been hardened.
+# See the caution block at the top of ../README.md.
+#
+# Part of the same deliberately vulnerable stack.
+#
 Description:  This template deploys a VPC, with a pair of public and private subnets spread
   across two Availability Zones. It deploys an internet gateway, with a default
   route on the public subnets. It deploys a pair of NAT gateways (one in each AZ),

--- a/validate-policies.py
+++ b/validate-policies.py
@@ -1,0 +1,43 @@
+import json, glob, sys
+
+# The IAM JSON policy grammar is a CLOSED set. Anything else is rejected with
+# MalformedPolicyDocument, so a stray key makes the file unusable rather than merely untidy.
+POLICY_KEYS = {'Version', 'Id', 'Statement'}
+STMT_KEYS = {'Sid', 'Effect', 'Principal', 'NotPrincipal', 'Action', 'NotAction',
+             'Resource', 'NotResource', 'Condition'}
+
+bad = 0
+for f in sorted(glob.glob('**/*.json', recursive=True)):
+    try:
+        d = json.load(open(f))
+    except Exception as e:
+        print(f'  INVALID JSON  {f}: {e}'); bad += 1; continue
+    if not isinstance(d, dict) or 'Statement' not in d:
+        continue
+    for k in d:
+        if k not in POLICY_KEYS:
+            print(f'  BAD TOP KEY   {f}: {k!r}'); bad += 1
+    stmts = d['Statement']
+    if isinstance(stmts, dict): stmts = [stmts]
+    for i, st in enumerate(stmts):
+        for k in st:
+            if k not in STMT_KEYS:
+                print(f'  BAD STMT KEY  {f} statement[{i}]: {k!r}'); bad += 1
+        if 'Effect' not in st:
+            print(f'  MISSING Effect {f} statement[{i}]'); bad += 1
+        # The alphanumeric-only Sid rule applies to IAM IDENTITY policies. Per the same AWS
+        # grammar page, "other AWS services that support resource policies may have other
+        # requirements ... some services allow additional characters such as spaces". A KMS key
+        # policy is one: the AWS console itself generates Sids like
+        # "Allow access for Key Administrators". A statement carrying a Principal is
+        # resource-based, so the rule is applied only where it holds.
+        #
+        # This check was over-strict on its first run and flagged six valid KMS statements. That
+        # is worth recording: a linter that reports valid input is worse than no linter, because
+        # the next person "fixes" the input to satisfy it.
+        sid = st.get('Sid')
+        is_resource_policy = 'Principal' in st or 'NotPrincipal' in st
+        if sid is not None and not is_resource_policy and not str(sid).isalnum():
+            print(f'  NON-ALNUM Sid  {f} statement[{i}]: {sid!r} (IAM identity policies allow A-Za-z0-9 only)'); bad += 1
+print(f'  policy files with problems: {bad}')
+sys.exit(1 if bad else 0)

--- a/validate-policies.py
+++ b/validate-policies.py
@@ -5,39 +5,90 @@ import json, glob, sys
 POLICY_KEYS = {'Version', 'Id', 'Statement'}
 STMT_KEYS = {'Sid', 'Effect', 'Principal', 'NotPrincipal', 'Action', 'NotAction',
              'Resource', 'NotResource', 'Condition'}
+VALID_VERSIONS = {'2008-10-17', '2012-10-17'}
 
 bad = 0
+
+
+def problem(msg):
+    global bad
+    print(f'  {msg}')
+    bad += 1
+
+
 for f in sorted(glob.glob('**/*.json', recursive=True)):
     try:
         d = json.load(open(f))
     except Exception as e:
-        print(f'  INVALID JSON  {f}: {e}'); bad += 1; continue
+        problem(f'INVALID JSON   {f}: {e}')
+        continue
     if not isinstance(d, dict) or 'Statement' not in d:
         continue
+
     for k in d:
         if k not in POLICY_KEYS:
-            print(f'  BAD TOP KEY   {f}: {k!r}'); bad += 1
+            problem(f'BAD TOP KEY    {f}: {k!r}')
+    if 'Version' in d and d['Version'] not in VALID_VERSIONS:
+        problem(f'BAD Version    {f}: {d["Version"]!r} (only {sorted(VALID_VERSIONS)})')
+
     stmts = d['Statement']
-    if isinstance(stmts, dict): stmts = [stmts]
+    if isinstance(stmts, dict):
+        stmts = [stmts]
+    if not isinstance(stmts, list):
+        problem(f'BAD Statement  {f}: must be an object or a list, got {type(stmts).__name__}')
+        continue
+    # An empty Statement list parses as JSON and is rejected by IAM. The first version of this
+    # checker returned success for it, which is the vacuous pass a linter exists to prevent.
+    if not stmts:
+        problem(f'EMPTY Statement {f}: a policy needs at least one statement')
+        continue
+
     for i, st in enumerate(stmts):
+        # Guard the type BEFORE touching keys. A non-object statement used to raise
+        # AttributeError and abort the whole run, so one malformed file hid every other file.
+        if not isinstance(st, dict):
+            problem(f'BAD STMT TYPE  {f} statement[{i}]: {type(st).__name__}, expected an object')
+            continue
+
         for k in st:
             if k not in STMT_KEYS:
-                print(f'  BAD STMT KEY  {f} statement[{i}]: {k!r}'); bad += 1
-        if 'Effect' not in st:
-            print(f'  MISSING Effect {f} statement[{i}]'); bad += 1
-        # The alphanumeric-only Sid rule applies to IAM IDENTITY policies. Per the same AWS
-        # grammar page, "other AWS services that support resource policies may have other
-        # requirements ... some services allow additional characters such as spaces". A KMS key
-        # policy is one: the AWS console itself generates Sids like
-        # "Allow access for Key Administrators". A statement carrying a Principal is
-        # resource-based, so the rule is applied only where it holds.
+                problem(f'BAD STMT KEY   {f} statement[{i}]: {k!r}')
+
+        # Effect must be present AND one of two literals. Checking only presence let
+        # "Effect": "allow" through, which IAM rejects for case.
+        eff = st.get('Effect')
+        if eff is None:
+            problem(f'MISSING Effect {f} statement[{i}]')
+        elif eff not in ('Allow', 'Deny'):
+            problem(f'BAD Effect     {f} statement[{i}]: {eff!r} (must be "Allow" or "Deny")')
+
+        # Exactly one of Action / NotAction. Neither means the statement grants nothing and
+        # IAM rejects it; both is also invalid.
+        has_a, has_na = 'Action' in st, 'NotAction' in st
+        if has_a and has_na:
+            problem(f'BOTH Action    {f} statement[{i}]: Action and NotAction are exclusive')
+        elif not has_a and not has_na:
+            problem(f'NO Action      {f} statement[{i}]: needs Action or NotAction')
+
+        # Resource is required in identity policies. In a resource policy the resource is
+        # implicit (a KMS key policy scopes to its own key), so it is only required when there
+        # is no Principal.
+        is_resource_policy = 'Principal' in st or 'NotPrincipal' in st
+        if not is_resource_policy and not ('Resource' in st or 'NotResource' in st):
+            problem(f'NO Resource    {f} statement[{i}]: identity policies need Resource')
+
+        # The alphanumeric-only Sid rule applies to IAM IDENTITY policies. Per the AWS grammar
+        # page, "other AWS services that support resource policies may have other requirements
+        # ... some services allow additional characters such as spaces". A KMS key policy is
+        # one: the AWS console itself generates Sids like "Allow access for Key Administrators".
         #
         # This check was over-strict on its first run and flagged six valid KMS statements. That
         # is worth recording: a linter that reports valid input is worse than no linter, because
         # the next person "fixes" the input to satisfy it.
         sid = st.get('Sid')
-        is_resource_policy = 'Principal' in st or 'NotPrincipal' in st
         if sid is not None and not is_resource_policy and not str(sid).isalnum():
-            print(f'  NON-ALNUM Sid  {f} statement[{i}]: {sid!r} (IAM identity policies allow A-Za-z0-9 only)'); bad += 1
+            problem(f'NON-ALNUM Sid  {f} statement[{i}]: {sid!r} '
+                    '(IAM identity policies allow A-Za-z0-9 only)')
+
 print(f'  policy files with problems: {bad}')
 sys.exit(1 if bad else 0)


### PR DESCRIPTION
Six topics of AWS notes from mid-2020. The headline is a distinction rather than a fix: `security/` is **deliberately insecure** and has been labelled rather than hardened, while everything outside it had real defects and has been corrected.

## `security/` is training material. It is now labelled, not fixed.

`security/infrastructure/app.yml` opens `IpProtocol: -1` from `0.0.0.0/0` **twice**, plus SSH on 22 and ports 5000 and 80, all to the internet. `s3.yml` creates three buckets, one named `secret-recipes`, with no encryption at rest, no public-access block and no versioning.

None of that is an oversight. It is a security training project: the exercises attack the stack with hydra, and the hardening exercise deliberately fixes SSH inside `sshd_config` on the running instance rather than in the template. **Hardening it would destroy the exercises.**

The real risk was that the repo published insecure CloudFormation with nothing saying so, and the root README was one line (`# AWS various`), so a reader could reasonably lift `s3.yml` as a reference. All three templates now open with a header naming the specific misconfigurations, and `security/README.md` leads with a caution block.

**Not one resource property changed there.** `cfn-lint` reports the same two `W2506` warnings on `app.yml` as `master` — counted on both sides to be sure the header changed nothing.

## A demo about encryption was printing its plaintext to the logs

`encryption-lambda-read.js` ended with:

```js
console.log(data.Body.toString('utf-8'))
```

So the last act of a function whose whole purpose is showing an object is encrypted at rest with a KMS CMK was writing the decrypted content into CloudWatch Logs. Logs are a different boundary from the bucket: not encrypted under that key, readable by anyone with `logs:FilterLogEvents`, persisting independently of the object.

It now logs the byte count and the SSE algorithm S3 reports, and **returns** the body to the caller — who is already authorised. The log group was the part that was not.

## Both Lambdas reported success when they had failed

Each caught its own errors with `console.log(err)` and returned `undefined`, so a denied `kms:Decrypt`, a missing object or a wrong bucket produced a *successful* invocation with nothing to show. They rethrow now, which is what makes the invocation fail, retry, and appear in metrics. Only `name` and `code` are logged, since an SDK error message can carry the bucket, key and whole request.

Bucket, key, KMS key id and body came from source rather than the environment — including a specific key ARN useless to anyone else. All four from `process.env`, and a missing `KMS_KEY_ID` is fatal rather than silently falling back to the bucket default.

## Two policies could disable the account's own monitoring

`cloudwatch-alarms-billing-CloudWatchMetricsPolicyForBilling.json` granted `cloudwatch:SetAlarmState` and `cloudwatch:DeleteAlarms` on `Resource: "*"` — permission to silence or delete **every alarm in the account**, from a policy whose stated purpose is one billing alarm.

The fix depended on which actions can be scoped, so I checked the CloudWatch service-authorization reference rather than guessing:

| action | resource-level? |
| --- | --- |
| `PutMetricAlarm`, `DeleteAlarms`, `DescribeAlarms`, `SetAlarmState` | **yes**, alarm ARN |
| `PutMetricData`, `GetMetricStatistics`, `ListMetrics` | no, `*` only |

Split along exactly that line, with the alarm half scoped to `alarm:billing-*`. Narrowing the metric half would deny rather than restrict. Same for `sns:DeleteTopic`, which was on `*`.

The two Lambda S3 policies also granted `GetObjectAcl`/`PutObjectAcl`, which neither function calls.

## `SSM/SSM.yml` could not be deployed as written

Four reasons:

- **`ImageId: ami-0323c3dd2da7fb37d` hardcoded.** An AMI id is valid only in its publishing region and Amazon deregisters old ones, so this failed outside `us-east-1` and eventually failed there too. Now the public SSM parameter for the latest Amazon Linux 2 — and that OS is an **inference stated as such**: the id can't be resolved any more, but the template installs no SSM agent, so its image must have shipped one.
- **`RoleName` hardcoded twice**, making the stack undeployable a second time.
- **No `VpcId` on the security group**, so it landed in the default VPC and failed outright where none exists.
- **The login role trusted `Principal: root`** — every identity in the account, no condition. It now requires MFA, which is the same control the sibling `IAM-role-for-users/test-trust-policy.json` already applied, so the repo had been inconsistent with its own recommendation.

Also: `AmazonEC2ReadOnlyAccess` dropped (read on every EC2 resource, for a role that needs one instance); egress made explicit, since omitting it silently applies allow-all.

One thing is **deliberately not** a `!Sub`, and now says so:

```yaml
Resource: arn:aws:ssm:*:*:session/${aws:username}-*
```

`${aws:username}` is an IAM policy variable IAM expands at evaluation time, so it must reach IAM literally. Verified: `cfn-lint` rejects the `!Sub` form with `E1019 'aws:username' is not one of [...]` and accepts the literal.

## A policy validator, and why it exists

`validate-policies.py` checks every `*.json` against the IAM grammar, which is a **closed** set of keys — an unrecognised element is rejected with `MalformedPolicyDocument`, making the file unusable rather than untidy.

It exists because **writing this up broke two policies.** I added explanatory `"Comment"` keys to five statements, which IAM does not permit and JSON has no comment syntax to replace. That is why every explanation lives in a README instead.

The first version of the checker was then **over-strict and reported six valid statements as broken**: it applied the alphanumeric-only `Sid` rule to the KMS key policies, and that rule is for IAM *identity* policies. Resource policies allow more, and the AWS console generates `Sid: "Allow access for Key Administrators"` itself. Now scoped to statements without a `Principal`. A linter that reports valid input is worse than none, because the next person changes the input to satisfy it.

Poison-tested both directions: 0 on the real policies, and it catches an injected `Comment` key and a spaced `Sid` on an identity policy.

## Smaller

- **Placeholders were spelled four ways** — `your-aws-account-id`, `your-account-id`, `your-admin-account-id` — beside a concrete bucket name and a real KMS key id that read as placeholders but were not. 68 occurrences unified. `security/txt/` is untouched, being the student's own answers.
- **No root `.gitignore`**, only a nested one holding a single cloudsploit path, in a repo whose walkthroughs have you create access keys, roles and key pairs. Root one added covering `.env*`, `*.pem`, `*.key`, `*.p12`, `*.pfx`, `credentials*`, `secrets/`, a local `.aws/`, logs and databases; the cloudsploit path is absorbed and `git check-ignore` confirms it still matches.
- **Four blocks of command output were fenced as ```shell**, which is what makes a `bash -n` sweep report false failures. All 102 remaining shell blocks parse under **both** `bash -n` and `zsh -n`.

## One thing I got wrong and did not change

I flagged the two `key-policy.json` files under `encryption/` as accidental duplication with drift. They are **two deliberate stages**: `application/`'s is the top-level policy plus permission for the two Lambda roles, because the serverless walkthrough is the later stage of the same demo. Neither is stale. Recorded in the README so it is not mistaken for an oversight.

## Not covered

- **Nothing here has been run against AWS.** No credentials in this environment. Policies validated against the IAM grammar, templates with `cfn-lint`, Lambda sources with `node --check`; recorded output is from 2020.
- **`security/` is unchanged apart from the warnings.**
- **`cloudtrail.md` and `cloudwatch-alarms-billing.md` keep their recorded output**, timestamps and resource ids included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable infrastructure for VPC, subnet, AMI, and instance type selection.
  - Added outputs for instance, role, and AMI details.
  - Added recursive IAM policy validation with clear error reporting.

- **Bug Fixes**
  - Improved encryption workflows with configuration validation, error handling, and reduced sensitive logging.
  - Restricted billing, SNS, S3, and Session Manager permissions to appropriate resources.
  - Added MFA requirements and outbound-only security group access.

- **Documentation**
  - Standardized account, bucket, and key placeholders.
  - Added warnings for intentionally insecure training templates.
  - Expanded repository, encryption, and deployment guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->